### PR TITLE
Fix "No images found" when passing "." as the directory

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -407,12 +407,15 @@ fn gather_file_list( path_list : &Vec<String>, config: &imagehash::ConfigOptions
 			
 }
 
-/// Filter to ignore invisible files that start with a dot
+/// Filter to ignore invisible files that start with a dot.
+/// The root entry (depth 0) is never filtered, otherwise passing "." or "./"
+/// as the directory would exclude the whole traversal.
 fn dir_filter(entry: &DirEntry) -> bool {
-    entry.file_name()
-         .to_str()
-         .map(|s| s.starts_with("."))
-         .unwrap_or(false)
+    entry.depth() > 0
+         && entry.file_name()
+              .to_str()
+              .map(|s| s.starts_with("."))
+              .unwrap_or(false)
 }
 
 /// Accepts a list of file paths and returns an ordered list of metadata with possible (but not confirmed) duplicates grouped together


### PR DESCRIPTION
Running `photodedupe .` (or `photodedupe ./`) in a directory full of images reports `No images found.`, even though passing the directory by name or absolute path works fine.

## Cause

`dir_filter` skips dotfiles, and it is passed to `WalkDir::filter_entry`. But `filter_entry` also applies the predicate to the **root entry**, and when the predicate rejects a *directory*, walkdir does not descend into it. The root entry for `.` / `./` has a file name starting with `.`, so the entire traversal is filtered out before any files are seen.

This is why `photodedupe .` fails while `photodedupe somedir` and `photodedupe /abs/path` both work.

## Fix

Exclude the root entry (`depth() == 0`) from the hidden-file filter. Dotfiles and dot-directories inside the tree are still skipped; the supplied directory is always traversed.

## Verification

Before: `photodedupe .` -> `No images found.`
After: `photodedupe .` lists images correctly, matching the output of `photodedupe /abs/path`.